### PR TITLE
Fix the translations being incorrect

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -26,7 +26,7 @@ const globPattern = (shouldIncludeJson: boolean): string => (shouldIncludeJson ?
  * @returns string[] - The path split with the namespace
  */
 const configureNamespaceIfNeeded = (pathSplit: string[], namespace?: string | null | false): string[] => {
-  return namespace && namespace.length > 0 ? pathSplit.splice(1, 0, namespace) : pathSplit;
+  return namespace && namespace.length > 0 && pathSplit.splice(1, 0, namespace), pathSplit;
 };
 
 /**


### PR DESCRIPTION
### Before (v0.3.0)
```json
{
  "foo": "bar"
}
```

### After (before v0.3.0 and what is now)
```
{
  "en_US": {
    "translation": {
      "foo": "bar"
    }
  }
}
```

Closes #43